### PR TITLE
Refactored connection code to use connection manager

### DIFF
--- a/snowboard.py
+++ b/snowboard.py
@@ -76,6 +76,43 @@ def parseNames(conn, raw):
 		
 	return names
 
+class Connection:
+	"""Connection context manager.
+	
+	The `telnetlib.Telnet` class does not support the context manager before
+	Python 3.6. This is a bummer. To remedy that, this is a simply wrapper
+	class that turns `telnetlib.Telnet` into a context manager.
+	
+	To use, simply convert:
+	    conn = telnetlib.Telnet("irc.server.net")
+	    # do stuff with conn
+	    conn.close()
+	to:
+	    with Connection("irc.server.net") as conn:
+				# do stuff with conn
+	"""
+	 
+	def __init__(self, server, port=6667):
+		"""Prepare connection.
+		"""
+		self._server = server
+		self._port   = port
+		
+		self._conn = None
+	
+	def __enter__(self):
+		"""Connect to a server.
+		"""
+		self._conn = telnetlib.Telnet(self._server, port=self._port)
+		return self._conn
+	
+	def __exit__(self, exc_type, exc_value, traceback):
+		"""Close server connection.
+		"""
+		if self._conn is not None:
+			self._conn.close()
+			self._conn = None
+
 # Connect to the server.
 # TODO - Error handling needs to be done
 def serverConnect():
@@ -93,6 +130,12 @@ def serverConnect():
 	serverSend(conn, userLine)
 		
 	return conn
+
+def serverAuthenticate(conn, nick, realname):
+	"""Log into IRC.
+	"""
+	serverSend(conn, "NICK " + nick)
+	serverSend(conn, "USER " + nick + " 0 * :" + realname)
 
 # Disconnect from the server properly.
 def serverDisconnect(conn):
@@ -121,59 +164,67 @@ def main(argv):
 	
 	result = 0	# Define a result value, so we can pass it back to the shell
 	
-	# Open the initial connection.
-	connected = False
-	conn = serverConnect()
-	message = serverLine(conn)
-	
-	while not connected:
-		response = message.split()
-		if response[1] == "396":
-			connected = True
+	with Connection(SERV, port=SERVPORT) as conn:
+		# Get server name.
+		conn.read_until(b'\r\n')
+		global SEVERNAME
+		SERVERNAME = conn.read_until(b'\r\n').split()[0][1:].decode('utf-8')
 		
-		message = serverLine(conn)
-	
-	# Join all the configured channels.
-	channels = joinChannels(conn)
-	
-	# Process IRC messages.
-	while connected:
-		message = serverLine(conn)
-		if message == False:
-			connected = False
-			continue
+		# Authenticate.
+		serverAuthenticate(conn, BOTNICK, REALNAME)
 		
-		response = message.split()
+		# Complete connection.
+		while True:
+			message = serverLine(conn)
+			### TODO:
+			### If we're not going to let serverLine throw, then we'll have
+			### to handle errors here, somehow.
+			response = message.split()
+			if response[1] == "396":
+				break
 		
-		#print(message)
+		# Join all the configured channels.
+		channels = joinChannels(conn)
+		print("SARIA channels =", channels)
 		
-		# Process WHO responses to get hostnames.
-		if response[1] == "352":
-			for channel in channels:
-				for name in channel.names:
-					if name.nick.lower() == response[4].lower():
-						name.setHost(response[5])
-		# Process NAMES responses to get all names for channels joined.
-		elif response[1] == "353":
-			names = parseNames(conn, message)
-			for channel in channels:
-				if channel.name.lower() == response[4].lower():
-					channel.updateNames(names)
-		elif response[0] == "PING":
-			serverSend(conn, "PONG " + response[1])
-		
-		# Get the list of commands to perform from the scripts
-		commands = runScripts(message)
-
-		# Execute commands
-		for command in commands:
-			if command == "*QUIT*":
-				serverDisconnect(conn)
-			else:
-				serverSend(conn, commands)
-	
-	# Disconnect
-	conn.close()
+		# Process IRC messages.
+		while True:
+			message = serverLine(conn)
+			if message == False:
+				break
+			
+			response = message.split()
+			
+			#print(message)
+			
+			# Process WHO responses to get hostnames.
+			if response[1] == "352":
+				for channel in channels:
+					for name in channel.names:
+						if name.nick.lower() == response[4].lower():
+							name.setHost(response[5])
+			# Process NAMES responses to get all names for channels joined.
+			elif response[1] == "353":
+				names = parseNames(conn, message)
+				for channel in channels:
+					if channel.name.lower() == response[4].lower():
+						channel.updateNames(names)
+			elif response[0] == "PING":
+				serverSend(conn, "PONG " + response[1])
+			
+			# Get the list of commands to perform from the scripts
+			commands = runScripts(message)
+			
+			# Execute commands
+			for command in commands:
+				if command == "*QUIT*":
+					### TODO:
+					### Rather than sending the QUIT command then continuing to
+					### loop with what should be a dead connection, perhaps we
+					### should set a flag and then break out of the main loop?
+					serverDisconnect(conn)
+				else:
+					serverSend(conn, commands)
 	
 	# Print the message about disconnection.
 	print("Disconnected from the server.")


### PR DESCRIPTION
So what this PR is about is I created a context manager to handle connections, and do clean up for all paths (normal and error). Then I refactored all the connection code in main to use the context manager. This allowed me to remove some unnecessary boolean flags (there is no need to check whether `connection` is `True`, because inside the `with` block, we're always connected.

I left the original `serverConnect()` function untouched for now. But eventually it can probably be removed.