### PR TITLE
Added verbose command-line options

### DIFF
--- a/snowboard.py
+++ b/snowboard.py
@@ -13,6 +13,9 @@ from config import *
 from channels import *
 from scripts import *
 
+# Program options
+options = None
+
 # Global place to store the name of the server you're actually on.
 SERVERNAME = ""
 
@@ -150,17 +153,17 @@ def joinChannels(conn):
 		joinChannel(conn, chan)
 	return channels
 
-# Program arguments
-args = None
-
 def main(argv):
 	argparser = argparse.ArgumentParser(
 		prog="snowboard",
 		description="IRC Bot Written in Python 3.",
 		fromfile_prefix_chars="@")
 	
-	global args
-	args = argparser.parse_args(argv)
+	argparser.add_argument("--verbose", "-v", action="count", default=0,
+		help="increase output verbosity")
+	
+	global options
+	options = argparser.parse_args(argv)
 	
 	result = 0	# Define a result value, so we can pass it back to the shell
 	


### PR DESCRIPTION
You can now use `--verbose`/`-v` options on the command-line. You can use `-v` multiple times, and each time you use it, it increases the verbosity level by one.

The verbose options don't do anything yet.