### PR TITLE
Debug output functions

### DIFF
--- a/snowboard/config.py
+++ b/snowboard/config.py
@@ -17,3 +17,6 @@ BOTCHANS = {
 }
 
 options = None
+
+# Debug output verbosity (default 0)
+verbosity = 0

--- a/snowboard/debug.py
+++ b/snowboard/debug.py
@@ -1,0 +1,179 @@
+# This file is part of snowboard.
+# 
+# snowboard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# snowboard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with snowboard.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+from . import config
+
+def print_message(*objects, sep=" ", end="\n", file=sys.stdout, flush=False, level=1):
+    """Writes a message if the level is high enough.
+    
+    Works just like the standard print function, if and only if `level`
+    is at least `config.verbosity`. Otherwise it does nothing.
+    
+    Its primary purpose is as the underlying implementation for all the
+    normal output functions in the debug module.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    file : file-like
+        File-like object to write output to.
+    flush : bool
+        If `True`, flush `file` after output.
+    level : int
+        `config.verbosity` must be at least `level` for any output.
+    """
+    if level <= config.verbosity:
+        print(*objects, sep=sep, end=end, file=file, flush=flush)
+
+def debug_message(*objects, sep=" ", end="\n", type="DEBUG", level=3):
+    """Writes an error message if the level is high enough.
+    
+    If `level` is at least `config.verbosity`, basically equivalent to:
+        print("[" + type + "]: ", *objects, sep=sep, end=end, 
+            file=sys.stderr, flush=True)
+    Otherwise it does nothing.
+    
+    Its primary purpose is as the underlying implementation for all the
+    error output functions in the debug module.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    type : str
+        What to tag output as.
+    level : int
+        `config.verbosity` must be at least `level` for any output.
+    """
+    if level <= config.verbosity:
+        print("[", type, "]: ", sep="", end="", file=sys.stderr, flush=False)
+        print(*objects, sep=sep, end=end, file=sys.stderr, flush=True)
+
+def message(*objects, sep=" ", end="\n", file=sys.stdout, flush=False):
+    """Writes a message if `config.verbosity` is at least 1.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    file : file-like
+        File-like object to write output to.
+    flush : bool
+        If `True`, flush `file` after output.
+    """
+    print_message(*objects, sep=sep, end=end, file=file, flush=flush, level=1)
+
+def info(*objects, sep=" ", end="\n", file=sys.stdout, flush=False):
+    """Writes a message if `config.verbosity` is at least 2.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    file : file-like
+        File-like object to write output to.
+    flush : bool
+        If `True`, flush `file` after output.
+    """
+    print_message(*objects, sep=sep, end=end, file=file, flush=flush, level=2)
+
+def trace(*objects, sep=" ", end="\n", file=sys.stdout, flush=False):
+    """Writes a message if `config.verbosity` is at least 3.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    file : file-like
+        File-like object to write output to.
+    flush : bool
+        If `True`, flush `file` after output.
+    """
+    print_message(*objects, sep=sep, end=end, file=file, flush=flush, level=3)
+
+def error(*objects, sep=" ", end="\n"):
+    """Writes an error message.
+    
+    The message is written to `sys.stderr`.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    """
+    debug_message(*objects, sep=sep, end=end, type="ERROR", level=0)
+
+def warn(*objects, sep=" ", end="\n"):
+    """Writes a warning message.
+    
+    The message is written to `sys.stderr`.
+    
+    `config.verbosity` must be at least 1 to show any output.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    """
+    debug_message(*objects, sep=sep, end=end, type="WARNING", level=1)
+
+def debug(*objects, sep=" ", end="\n"):
+    """Writes a debug message.
+    
+    The message is written to `sys.stderr`.
+    
+    `config.verbosity` must be at least 3 to show any output.
+    
+    Parameters
+    ----------
+    objects : positional parameter pack of objects
+        Each object in `*objects` is converted to `str` and printed in turn.
+    sep : str
+        Value output between each item in `objects`.
+    end : str
+        Value output at the end.
+    """
+    debug_message(*objects, sep=sep, end=end, type="DEBUG", level=3)

--- a/snowboard/main.py
+++ b/snowboard/main.py
@@ -16,6 +16,8 @@ def __parse_args(argv):
         help="increase output verbosity")
     
     config.options = argparser.parse_args(argv)
+    
+    config.verbosity = config.options.verbose
 
 def __get_message(conn):
     """Get a message from the server.


### PR DESCRIPTION
I added a debug module with a bunch of output functions.

All you need to do is include the debug module wherever you want to use it, then call the functions:

~~~.py
from . import debug

debug.message("Your message here.")
# prints "Your message here." to stdout,
# if and only if config.verbosity is at least 1

debug.warn("There's a possible problem here!")
# prints "[WARNING]: There's a possible problem here!" to stderr,
# if and only if config.verbosity is at least 1
~~~

To set the output verbosity, just use `-v`/`--verbose` on the command line. The more times you use it, the higher the verbosity level. Right now the maximum verbosity is 3, so "`./snowboard.py -vvv`" will set the maximum verbosity.

The output functions work like the standard `print()` function: They all take a list of objects that are converted to strings and printed, an optional `sep` string, and an optional `end` string.

Function|Output format|Minimum verbosity level|Writes to
----------|--------------|----------|----------
`message`|`<message>`|1|`stdout`
`info`|`<message>`|2|`stdout`
`trace`|`<message>`|3|`stdout`
`error`|`[ERROR]: <message>`|1|`stderr`
`warn`|`[WARNING]: <message>`|1|`stderr`
`debug`|`[DEBUG]: <message>`|3|`stderr`

There's also `message_print` and `debug_print`, if you want to write your own output functions.