### PR TITLE
All SQLite access converted to use context manager and prepared statements

### DIFF
--- a/snowboard/seen.py
+++ b/snowboard/seen.py
@@ -19,19 +19,96 @@ Keep track of nicks, hosts, and who last said what.
 See https://github.com/dwhagar/snowboard/wiki/Class-Docs for documentation.
 '''
 
+import contextlib
 import sqlite3
 import time
+
+_SQL_CREATE_HOSTS_TABLE = """
+    CREATE TABLE IF NOT EXISTS hosts (
+        nick  TEXT PRIMARY KEY,
+        hosts TEXT,
+        time  INTEGER,
+        act   TEXT
+    )
+"""
+
+_SQL_CREATE_NICKS_TABLE = """
+    CREATE TABLE IF NOT EXISTS nicks (
+        host  TEXT PRIMARY KEY,
+        nicks TEXT,
+        time  INTEGER,
+        act   TEXT)
+"""
+
+__SQL_INSERT_INTO_HOSTS = """
+    INSERT INTO hosts
+        (nick, hosts, time, act)
+        VALUES
+        (:nick, :hosts, :time, :act)
+"""
+
+__SQL_INSERT_INTO_NICKS = """
+    INSERT INTO nicks
+        (host, nicks, time, act)
+        VALUES
+        (:host, :nicks, :time, :act)
+"""
+
+__SQL_SELECT_ACT_FROM_HOSTS_BY_NICK = """
+    SELECT act, time FROM hosts WHERE nick = :nick
+""" # LIMIT 1?
+
+__SQL_SELECT_ACT_FROM_NICKS_BY_HOST = """
+    SELECT act, time FROM nicks WHERE host = :host
+""" # LIMIT 1?
+
+__SQL_SELECT_HOSTS_FROM_HOSTS_BY_NICK = """
+    SELECT hosts FROM hosts WHERE nick = :nick
+""" # LIMIT 1?
+
+__SQL_SELECT_NICKS_FROM_NICKS = "SELECT nicks FROM nicks"
+
+__SQL_SELECT_NICKS_FROM_NICKS_BY_HOST = """
+    SELECT nicks FROM nicks WHERE host = :host
+""" # LIMIT 1?
+
+_SQL_UPDATE_ACT_IN_HOSTS = """
+    UPDATE hosts
+        SET act = :act, time = :time
+        WHERE nick = :nick
+"""
+
+_SQL_UPDATE_ACT_IN_NICKS = """
+    UPDATE nicks
+        SET act = :act, time = :time
+        WHERE host = :host
+"""
+
+__SQL_UPDATE_HOSTS_IN_HOSTS = """
+    UPDATE hosts
+        SET hosts = :hosts
+        WHERE nick = :nick
+"""
+
+__SQL_UPDATE_NICKS_IN_NICKS = """
+    UPDATE nicks
+        SET nicks = :nicks
+        WHERE host = :host
+"""
 
 class Seen:
     '''Connection to the database where seen data will be stored.'''
 
     def __init__(self, network):
         self.network = network
-        self.database = network.lower() + ".db"
-        self.conn = None
-        self.db = None
 
-        self.__initDB()  # Make sure there is a database and it has the table.
+        self.__dbname = network.lower() + ".db"
+
+        # Make sure there is a database and it has the table.
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                cursor.execute(_SQL_CREATE_HOSTS_TABLE)
+                cursor.execute(_SQL_CREATE_NICKS_TABLE)
 
     def hostSearch(self, host):
         '''Finds all hosts associated with a nick.'''
@@ -98,71 +175,37 @@ class Seen:
 
     def loadHostAction(self, host):
         '''Load action from a given nick.'''
-        result = None
-
-        self.__openDB()
-
-        query = "SELECT act, time FROM nicks WHERE host IS '" + host.lower() + "'"
-        self.db.execute(query)
-        data = self.db.fetchone()
-
-        if not data is None:
-            result = (data[0], data[1])
-
-        self.__closeDB()
-
-        return result
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_ACT_FROM_NICKS_BY_HOST, { "host" : host.lower() }):
+                    act, time = row
+                    return row
+        return None
 
     def loadHosts(self, nick):
         '''Loads a list of hosts from the nick given.'''
-        result = None
-
-        self.__openDB()
-
-        query = "SELECT hosts FROM hosts WHERE nick IS '" + nick.lower() + "'"
-        self.db.execute(query)
-        data = self.db.fetchone()
-
-        if not data is None:
-            result = data[0].split(",")
-
-        self.__closeDB()
-
-        return result
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_HOSTS_FROM_HOSTS_BY_NICK, { "nick" : nick.lower() }):
+                    return row[0].split(",")
+        return None
 
     def loadNickAction(self, nick):
         '''Load action from a given nick.'''
-        result = None
-
-        self.__openDB()
-
-        query = "SELECT act, time FROM hosts WHERE nick IS '" + nick.lower() + "'"
-        self.db.execute(query)
-        data = self.db.fetchone()
-
-        if not data is None:
-            result = (data[0], data[1])
-
-        self.__closeDB()
-
-        return result
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_ACT_FROM_HOSTS_BY_NICK, { "nick" : nick.lower() }):
+                    act, time = row
+                    return row
+        return None
 
     def loadNicks(self, host):
         '''Loads a list of nicks from the nick given.'''
-        result = None
-
-        self.__openDB()
-
-        query = "SELECT nicks FROM nicks WHERE host IS '" + host.lower() + "'"
-        self.db.execute(query)
-        data = self.db.fetchone()
-
-        if not data is None:
-            result = data[0].split(",")
-
-        self.__closeDB()
-
-        return result
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_NICKS_FROM_NICKS_BY_HOST, { "host" : host.lower() }):
+                    return row[0].split(",")
+        return None
 
     def save(self, nick, host, act):
         '''Save a nick, host, and action to the DB'''
@@ -172,74 +215,93 @@ class Seen:
 
     def saveAction(self, nick, host, act):
         '''Saves the action and time for a user.'''
-
-        data = [act, time.time()]
-
-        nickQuery = "UPDATE hosts SET act = ?, time = ? WHERE nick IS '" + nick.lower() + "'"
-        hostQuery = "UPDATE nicks SET act = ?, time = ? WHERE host IS '" + host.lower() + "'"
-
-        self.__openDB()
-        self.db.execute(nickQuery, data)
-        self.db.execute(hostQuery, data)
-        self.__closeDB()
+        t = time.time()
+        # Could possibly compact both dictionaries into one, if sure there
+        # will be no issue between nick and host.
+        hosts_data = {
+            "nick" : nick.lower(),
+            "act"  : act,
+            "time" : t
+        }
+        nicks_data = {
+            "host" : host.lower(),
+            "act"  : act,
+            "time" : t
+        }
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                cursor.execute(_SQL_UPDATE_ACT_IN_HOSTS, hosts_data)
+                cursor.execute(_SQL_UPDATE_ACT_IN_NICKS, nicks_data)
 
     def saveHost(self, nick, host):
         '''Saves the nick and host to the database.'''
-        hosts = self.loadHosts(nick)
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            # First load hosts.
+            hosts = None
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_HOSTS_FROM_HOSTS_BY_NICK, { "nick" : nick.lower() }):
+                    hosts = row[0].split(",")
 
-        if hosts is None:
-            hosts = [host.lower()]
-            data = [nick.lower(), ",".join(hosts), 0, ""]
-            query = "INSERT INTO hosts VALUES (?, ?, ?, ?)"
-        else:
-            if not (host.lower() in map(str.lower, hosts)):
-                hosts.append(host.lower())
-                if len(hosts) > 20:
-                    hosts = hosts[-20:]
-            data = [nick.lower(), ",".join(hosts)]
-            query = "UPDATE hosts SET nick = ?, hosts = ? WHERE nick IS '" + nick.lower() + "'"
+            if not hosts:
+                data = {
+                    "nick"  : nick.lower(),
+                    "hosts" : host.lower(),
+                    "time"  : 0,
+                    "act"   : ""
+                }
+                sql = __SQL_INSERT_INTO_HOSTS
+            else:
+                if not (host.lower() in map(str.lower, hosts)):
+                    hosts = hosts[-19:] + [host.lower()]
+                data = {
+                    "nick"  : nick.lower(),
+                    "hosts" : ",".join(hosts)
+                }
+                sql = __SQL_UPDATE_HOSTS_IN_HOSTS
 
-        self.__openDB()
-        self.db.execute(query, data)
-        self.__closeDB()
+            with connection as cursor:
+                cursor.execute(sql, data)
 
     def saveNick(self, nick, host):
         '''Saves the nick and host to the database.'''
-        nicks = self.loadNicks(host)
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            # First load nicks.
+            nicks = None
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_NICKS_FROM_NICKS):
+                    nicks = row[0].split(",")
 
-        self.__openDB()
+            if not nicks:
+                data = {
+                    "host"  : host.lower(),
+                    "nicks" : nick,
+                    "time"  : 0,
+                    "act"   : ""
+                    "
+                }
+                sql = __SQL_INSERT_INTO_NICKS
+            else:
+                if not (nick.lower() in map(str.lower, nicks)):
+                    nicks = nicks[-29:] + [nick]
+                data = {
+                    "host"  : host.lower(),
+                    "nicks" : ",".join(nicks)
+                }
+                sql = __SQL_UPDATE_NICKS_IN_NICKS
 
-        if nicks is None:
-            nicks = [nick]
-            data = [host.lower(), ",".join(nicks), 0, ""]
-            query = "INSERT INTO nicks VALUES (?, ?, ?, ?)"
-        else:
-            if not (nick.lower() in map(str.lower, nicks)):
-                nicks.append(nick)
-                if len(nicks) > 30:
-                    nicks = nicks[-30:]
-            data = [host.lower(), ",".join(nicks)]
-            query = "UPDATE nicks SET host = ?, nicks = ? WHERE host IS '" + host.lower() + "'"
-
-        self.db.execute(query, data)
-
-        self.__closeDB()
+            with connection as cursor:
+                cursor.execute(sql, data)
 
     def searchNicks(self, nick):
         '''Search through the nicks in the DB'''
         result = []
-        self.__openDB()
-
-        query = "SELECT nicks FROM nicks"
-
-        self.db.execute(query)
-        data = self.db.fetchall()
-
-        for row in data:
-            nickList = row[0].split(',')
-            for item in nickList:
-                if item.lower().find(nick.lower()) > -1:
-                    result.append(item)
+        with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
+            with connection as cursor:
+                for row in cursor.execute(__SQL_SELECT_NICKS_FROM_NICKS):
+                    nickList = row[0].split(',')
+                    for item in nickList:
+                        if item.lower().find(nick.lower()) > -1:
+                            result.append(item)
 
         result = self.__removeDupes(result)
 
@@ -280,26 +342,3 @@ class Seen:
                 result.append(item)
 
         return result
-
-    def __closeDB(self):
-        '''Closes the user database.'''
-        self.conn.commit()
-        self.conn.close()
-        self.conn = None
-
-    def __initDB(self):
-        '''Intended to initialize a database that doesn't yet exist.'''
-        self.__openDB()
-
-        initNicks = "CREATE TABLE IF NOT EXISTS hosts (nick TEXT PRIMARY KEY, hosts TEXT, time INTEGER, act TEXT)"
-        initHosts = "CREATE TABLE IF NOT EXISTS nicks (host TEXT PRIMARY KEY, nicks TEXT, time INTEGER, act TEXT)"
-
-        self.db.execute(initNicks)
-        self.db.execute(initHosts)
-
-        self.__closeDB()
-
-    def __openDB(self):
-        '''Opens the user database up for use.'''
-        self.conn = sqlite3.connect(self.database)
-        self.db = self.conn.cursor()


### PR DESCRIPTION
This pull request resolves issue #37.

Three classes were changed, but all were changed substantially.

Basically, the classes previously all had a pair of functions: `__openDB()` and `__closeDB()`, and every function that used the database had to call first one then the other. `__closeDB()` was not only tasked with closing the database, it also committed any outstanding transactions.

There are two main problems with this.
1.  It is error-prone. It is far too easy to get lost in a long function and return without calling `__closeDB()`. (See, for example, `Users.uidExists()` in `users.py`.) It is also not exception-safe - if an exception were to be thrown after a successful database command but before `__closeDB()`, the effects of the command would basically be lost.
2.  It is very inefficient. There were several functions that called other functions that opened the database, did something, then closed the database... then the caller _re_-opened the database and did something else. (This problem still remains in the `Seen` class, but that's a whole other issue.)

Generally, all functions in all three classes that actually accessed databases were converted from this form:

``` py
def f(self):
    self.__openDB()

    # self.db is set in __openDB()
    self.db.execute(query)

    data = self.db.fetchone()
    if data is not None:
        # return data
    else:
        # return defaults
```

to this form:

``` py
def f(self):
    with contextlib.closing(sqlite3.connect(self.__dbname)) as connection:
        with connection as cursor:
            for data in cursor.execute(query):
                # return data
    #return defaults
```

All SQL statements were also pulled out of the code and placed separately at the top of the files. This will make it easier to figure out any changes that have to be made if the database structure changes.

This pull request also resolves several other minor issues.

A potential future improvement is a new module `database`, with a `db_open()` function. Then there would be no need for the `contextlib` machinery anywhere else, leaving you with this:

``` py
from .database import db_open

def f(self):
    with db_open(self.__dbname) as db:
        with db:
            # first transaction
            db.execute(query)
        # first transaction auto-commits
        with db:
            # second transaction
            db.execute(query)
        # second transaction auto-commits
    # database auto-closes
```
